### PR TITLE
Fix NULL error

### DIFF
--- a/lua/entities/gmod_sent_vehicle_fphysics_base/spawn.lua
+++ b/lua/entities/gmod_sent_vehicle_fphysics_base/spawn.lua
@@ -573,10 +573,13 @@ function ENT:SetupVehicle()
 
 		for i = 1, table.Count( self.Wheels ) do
 			local Ent = self.Wheels[ i ]
-			local PhysObj = Ent:GetPhysicsObject()
+			
+			if IsValid( Ent ) then
+				local PhysObj = Ent:GetPhysicsObject()
 
-			if IsValid( PhysObj ) then
-				PhysObj:EnableMotion( true )
+				if IsValid( PhysObj ) then
+					PhysObj:EnableMotion( true )
+				end
 			end
 		end
 


### PR DESCRIPTION
Fixes:
```
[simfphys_base-master] addons/simfphys_base-master/lua/entities/gmod_sent_vehicle_fphysics_base/spawn.lua:576: Tried to use a NULL entity!
1. GetPhysicsObject - [C]:-1
 2. unknown - addons/simfphys_base-master/lua/entities/gmod_sent_vehicle_fphysics_base/spawn.lua:576
```